### PR TITLE
Hotfix : Fixed games played statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1-beta] - 2026-05-15
+
+### Fixed
+- **Analytics**: Restored missing game start logs in Classic and High/Low modes.
+- **Stats**: Fixed an issue where the global number of played games was not incrementing in the statistics dashboard.
+
 ## [0.1.0-beta] - 2026-05-14
 
 ### Added

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -162,6 +162,7 @@ export default function GamePage() {
       setCurrentJob(firstJob);
       setPage("playing");
       setLoadingStart(false);
+      logger.info("Classic game started");
     } catch (err) {
       setLoadingStart(false);
       alert("Erreur lors du chargement des offres. Veuillez réessayer.");

--- a/frontend/src/pages/HighLowGame.jsx
+++ b/frontend/src/pages/HighLowGame.jsx
@@ -55,6 +55,7 @@ export default function HighLowGame() {
         newJobs[0].salary = reveal.real_salary;
       }
       setJobs(newJobs);
+      logger.info("High/Low game started");
     } catch (err) {
       console.error("Start game failed", err);
     } finally {


### PR DESCRIPTION
# Pull Request: Fix Statistics Tracking (v0.1.1-beta)

## Overview
This PR resolves an issue where the "Games Played" statistic was not incrementing in the global statistics dashboard for Classic and High/Low game modes.

## Changes
### Frontend
- **GamePage.jsx**: Restored `logger.info("Classic game started")` in the game initialization sequence.
- **HighLowGame.jsx**: Restored `logger.info("High/Low game started")` in the game initialization sequence.
- **BattleRoyale.jsx**: Verified that "Battle Royale game started" logging is correctly maintained.

### Documentation
- Updated `CHANGELOG.md` to reflect version `v0.1.1-beta`.

## Technical Context
The backend `stats_parser.py` relies on parsing the phrase `"game started"` (case-insensitive) from the application logs to calculate global game activity. These logs were previously removed, causing the stats dashboard to stop updating.

## Verification
- [x] Manual check of Classic mode start logs.
- [x] Manual check of High/Low mode start logs.
- [x] Verified Stats Page fetch request reflects log parsing logic.
