### PR TITLE
Fixed backend tests for new pool offer building

### DIFF
--- a/backend/services/offer_pool.py
+++ b/backend/services/offer_pool.py
@@ -182,7 +182,7 @@ def build_offer_pool(target_size=POOL_TARGET_SIZE):
             selected_indices = set()
             
             for i in range(target_size):
-                t = i / (target_size - 1)
+                t = i / (target_size - 1) if target_size > 1 else 0
                 # Apply cosine curve to concentrate sampling at the borders
                 curved_t = (1 - math.cos(math.pi * t)) / 2
                 base_idx = int(curved_t * (n_candidates - 1))

--- a/backend/tests/test_multiplayer.py
+++ b/backend/tests/test_multiplayer.py
@@ -1,4 +1,5 @@
 import pytest
+from unittest.mock import patch
 from backend.multiplayer.room_manager import RoomManager
 from backend.multiplayer.games.battle_royale import BattleRoyaleGame
 from backend.multiplayer.base import GameState
@@ -45,8 +46,11 @@ def test_room_full(manager):
     assert player_id is None
     assert "full" in error.lower()
 
-def test_battle_royale_elimination(manager):
+@patch("backend.multiplayer.games.battle_royale.get_normalized_job")
+def test_battle_royale_elimination(mock_get_job, manager):
     """Test elimination logic in Battle Royale."""
+    mock_get_job.return_value = {"id": "test_job", "salary_real": 3000}
+    
     game = BattleRoyaleGame()
     code, host_id = manager.create_room("battle_royale", "Host", "sid_1")
     guest_id, _ = manager.join_room(code, "Guest", "sid_2")

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -59,20 +59,34 @@ def test_fetch_offers_401_retry(mock_get, mock_token):
 @patch("backend.services.offer_pool.parse_salary")
 def test_build_offer_pool(mock_parse, mock_fetch):
     """Test building the offer pool with valid and invalid salaries."""
-    mock_fetch.return_value = [
-        {"id": "j1", "salaire": {"libelle": "3000"}},
-        {"id": "j2", "salaire": {"libelle": "None"}},
+    from backend.services.offer_pool import OFFER_POOL, refill_in_progress
+    import backend.services.offer_pool as op
+    
+    # Reset pool state for testing
+    with op.pool_lock:
+        op.OFFER_POOL.clear()
+        op.refill_in_progress = False
+    
+    # Provide enough candidates to satisfy candidate_target = target_size * 5
+    # For target_size=1, we need 5 candidates.
+    mock_fetch.side_effect = [
+        [
+            {"id": "j1", "salaire": {"libelle": "1000"}},
+            {"id": "j2", "salaire": {"libelle": "2000"}},
+            {"id": "j3", "salaire": {"libelle": "3000"}},
+            {"id": "j4", "salaire": {"libelle": "4000"}},
+            {"id": "j5", "salaire": {"libelle": "5000"}},
+        ]
     ]
-    # Mock parse_salary to return 3000 for the first, None for the second
-    mock_parse.side_effect = [3000.0, None]
     
-    from backend.services.offer_pool import OFFER_POOL
-    OFFER_POOL.clear()
+    # Mock parse_salary for all 5 candidates
+    mock_parse.side_effect = [1000.0, 2000.0, 3000.0, 4000.0, 5000.0]
     
+    # Target size 1 means we need 5 candidates total (1 * 5)
     build_offer_pool(target_size=1)
     
     assert get_pool_size() == 1
     from backend.services.offer_pool import get_normalized_job
     job = get_normalized_job()
     assert job["id"] == "j1"
-    assert job["salary_real"] == 3000.0
+    assert job["salary_real"] == 1000.0


### PR DESCRIPTION
# Fix Backend Tests for New Offer Pool Logic

## Summary
Updated backend tests to support recent changes in offer pool building and salary diversity logic.

## Changes

### offer_pool.py
- Added a check for `target_size > 1` in the sampling loop to prevent a `ZeroDivisionError` when building a pool with a single item.

### test_services.py
- Modified `test_build_offer_pool` to reset global pool state (`refill_in_progress` and `OFFER_POOL`) before execution.
- Increased the number of mock candidates in the test to 5 to satisfy the new `candidate_target` requirement (5x target size).
- Updated salary assertions to match the new mock data.

### test_multiplayer.py
- Patched `get_normalized_job` in Battle Royale tests. This avoids timeouts caused by the 15-second wait for pool refills when the pool is empty at test start.
