### PR TITLE
Created new salary hiding function in the backend

### DIFF
--- a/backend/services/text_cleaner.py
+++ b/backend/services/text_cleaner.py
@@ -1,15 +1,48 @@
 from bs4 import BeautifulSoup
+import re
+
+
+def _mask_salary_text(text: str) -> str:
+    """Mask numeric salary values in a text string.
+
+    This function replaces numeric sequences that appear next to currency
+    symbols/words (€, euro, euros, eur) or salary-related tokens ("par mois", "/mois",
+    "mensuel") with bullet characters to avoid leaking salary information.
+    """
+    if not text:
+        return text
+
+    # Number pattern: handles groups like "1 200", "1.200", "1200", "1200,50"
+    number_pat = r"\d{1,3}(?:[ \u00A0.\u202F]\d{3})*(?:[.,]\d+)?|\d+"
+
+    def _repl(m):
+        s = m.group(0)
+        return "•" * len(s)
+
+    # Mask numbers that are followed by a currency token (e.g., "1200 €", "1200 euros")
+    text = re.sub(rf'({number_pat})(?=\s*(?:€|euros?|euro|eur))', _repl, text, flags=re.IGNORECASE)
+
+    # Mask numbers that come after a currency symbol (e.g., "€1200")
+    text = re.sub(rf'(?<=€)\s*({number_pat})', _repl, text, flags=re.IGNORECASE)
+
+    # Mask numbers followed by salary period tokens (e.g., "1200 par mois", "1200 /mois")
+    text = re.sub(rf'({number_pat})(?=\s*(?:/mois|par mois|mensuel|mensuelle))', _repl, text, flags=re.IGNORECASE)
+
+    return text
+
 
 def clean_html(text):
     """
-    Remove HTML tags and normalize whitespace in a string.
-    
+    Remove HTML tags, normalize whitespace, and mask salary numbers.
+
     Args:
         text (str): The raw text potentially containing HTML.
-        
+
     Returns:
-        str: The cleaned plain text.
+        str: The cleaned plain text with salary numbers masked.
     """
     if not text:
         return ""
-    return BeautifulSoup(text, "html.parser").get_text(" ", strip=True)
+
+    plain = BeautifulSoup(text, "html.parser").get_text(" ", strip=True)
+    return _mask_salary_text(plain)

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -90,3 +90,18 @@ def test_build_offer_pool(mock_parse, mock_fetch):
     job = get_normalized_job()
     assert job["id"] == "j1"
     assert job["salary_real"] == 1000.0
+
+
+def test_clean_html_masks_salaries():
+    """Ensure text_cleaner.clean_html masks salary numbers next to currency tokens."""
+    from backend.services.text_cleaner import clean_html
+    import re
+
+    html = "<p>Offre: 2 500 € par mois, prime: 1.200,50€ et bonus 3000 euros</p>"
+    out = clean_html(html)
+
+    # There should be no raw digit sequences directly adjacent to currency tokens
+    assert re.search(r"\d+\s*€", out) is None
+    assert re.search(r"\d+\s*euros?", out, re.IGNORECASE) is None
+    # Ensure we replaced numbers with bullet characters
+    assert "•" in out


### PR DESCRIPTION
# Hotfix: Mask salaries in backend text cleaner and add tests

Summary
- Prevent accidental salary leaks by masking numeric salary values in backend text processing.
- Adds a unit test to verify masking behavior.

Files changed
- [backend/services/text_cleaner.py](backend/services/text_cleaner.py): add salary-masking logic to `clean_html`.
- [backend/tests/test_services.py](backend/tests/test_services.py): add `test_clean_html_masks_salaries`.

Testing
- Run the new unit test locally:

```bash
pytest backend/tests/test_services.py::test_clean_html_masks_salaries -q
```

Notes
- Masking replaces detected numeric sequences near currency tokens (€, euro(s), `/mois`, `par mois`, `mensuel(e)`) with bullet characters (`•`) of the same length.
- Requires `beautifulsoup4` for HTML cleaning and `pytest` for tests.

If you want a different masking policy (fixed-length mask, more tokens, or stricter matching), I can update it quickly.