### PR TITLE
Security: Implemented anti-cheat measures 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,10 @@ DEBUG=True
 # Logging
 LOG_RETENTION_DAYS=30
 LOG_LEVEL=INFO
+
+# ==========================================================
+# SECURITY / ANTI-CHEAT
+# ==========================================================
+# Secret key required to call the POST /reset endpoint.
+# Generate with: python -c "import secrets; print(secrets.token_hex(32))"
+ADMIN_SECRET_KEY=change_me_to_a_strong_random_secret

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.3-beta] - 2026-05-17
+
+### Added
+- **Server-side Score Tracking**: Scores are no longer submitted by the client. The server now issues a session token at game start, accumulates per-round scores on each `/validate` call, and computes the final score on `/game_over`.
+- **Rate Limiting**: Added per-IP rate limits on all game endpoints (`/job`, `/validate`, `/log`, `/game_over`) via `slowapi`.
+- **Admin Key Protection**: The `/reset` endpoint now requires a secret `X-Admin-Key` header.
+
+### Fixed
+- **Log Injection**: The `/log` endpoint now rejects any message not in an explicit allowlist and strips score-related fields from the context, preventing stat manipulation via crafted requests.
+
+### Security
+- Socket.IO CORS origin changed from `*` to the configured `CORS_ORIGINS` value.
+
 ## [0.3.2-beta] - 2026-05-17
 
 ### Added

--- a/backend/config.py
+++ b/backend/config.py
@@ -46,5 +46,10 @@ LOG_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__)
 LOG_RETENTION_DAYS = int(os.getenv("LOG_RETENTION_DAYS", 30))
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
 
+# ==========================================================
+# SECURITY / ANTI-CHEAT CONFIGURATION
+# ==========================================================
+ADMIN_SECRET_KEY = os.getenv("ADMIN_SECRET_KEY", "")
+
 if not FRANCE_TRAVAIL_CLIENT_ID or not FRANCE_TRAVAIL_CLIENT_SECRET:
     raise ValueError("FRANCE_TRAVAIL_CLIENT_ID et FRANCE_TRAVAIL_CLIENT_SECRET requis")

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,6 @@
 """
 Main entry point for the SalaryGuessr API.
-Configures FastAPI, Socket.IO, and initializes the offer pool.
+Configures FastAPI, Socket.IO, rate limiting, and initializes the offer pool.
 """
 
 import sys
@@ -9,23 +9,40 @@ import threading
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Header, Request
 from fastapi.middleware.cors import CORSMiddleware
 from contextlib import asynccontextmanager
+from slowapi import Limiter, _rate_limit_exceeded_handler
+from slowapi.util import get_remote_address
+from slowapi.errors import RateLimitExceeded
 import socketio
 
-from .config import ENVIRONMENT, DEBUG, BACKEND_PORT, CORS_ORIGINS, POOL_TARGET_SIZE
+from .config import ENVIRONMENT, DEBUG, BACKEND_PORT, CORS_ORIGINS, POOL_TARGET_SIZE, ADMIN_SECRET_KEY
 from .services.offer_pool import get_random_job, get_pool_size, build_offer_pool, get_job_salary_data, get_job_salary
 from .services.salary_parser import parse_salary
 from .utils.memory import get_played_count, clear_played
 from .services.offer_pool import OFFER_POOL, refill_in_progress, get_normalized_job, strip_sensitive_info
 from .utils.logger import logger, access_logger, frontend_logger
 from .utils.stats_parser import get_global_stats
+from .utils.sessions import (
+    ALLOWED_LOG_MESSAGES,
+    create_session,
+    get_session,
+    record_round_score,
+    increment_streak,
+    finalize_session,
+    cleanup_old_sessions,
+)
 import time
 
 # Import multiplayer system
 from .multiplayer import get_room_manager, BattleRoyaleGame
 from .multiplayer.socket_handlers import SocketHandlers
+
+# ==========================================================
+# RATE LIMITER
+# ==========================================================
+limiter = Limiter(key_func=get_remote_address)
 
 # ==========================================================
 # INITIALIZATION
@@ -58,6 +75,9 @@ app = FastAPI(
     lifespan=lifespan
 )
 
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
 app.add_middleware(
     CORSMiddleware,
     allow_origins=CORS_ORIGINS,
@@ -72,9 +92,6 @@ async def log_requests(request, call_next):
     start_time = time.time()
     response = await call_next(request)
     process_time = (time.time() - start_time) * 1000
-    
-    # Don't log heartbeat/stats if you want even cleaner logs
-    # if request.url.path in ["/stats", "/"]: return response
 
     log_data = {
         "extra_data": {
@@ -93,9 +110,9 @@ logger.info(f"Allowed origins: {CORS_ORIGINS}")
 logger.info(f"Environment: {ENVIRONMENT}")
 
 # ==========================================================
-# SOCKET.IO
+# SOCKET.IO  — CORS locked to known origins
 # ==========================================================
-sio = socketio.AsyncServer(cors_allowed_origins='*', async_mode='asgi')
+sio = socketio.AsyncServer(cors_allowed_origins=CORS_ORIGINS, async_mode='asgi')
 sio_app = socketio.ASGIApp(sio)
 app.mount("/socket.io/", sio_app)
 
@@ -110,16 +127,19 @@ socket_handlers = SocketHandlers(sio)
 def root():
     """
     Root endpoint to check API status.
-    
+
     Returns:
         dict: Status message and current environment.
     """
     return {"message": "SalaryGuessr API running", "environment": ENVIRONMENT}
 
+
 @app.get("/job")
-def job():
+@limiter.limit("60/minute")
+def job(request: Request):
     """
     Fetch a random job offer without the real salary (Anti-Cheat).
+    Rate limited to 60 requests/minute per IP.
     """
     try:
         # include_salary=False ensures salary_real is NOT sent to the browser
@@ -128,22 +148,43 @@ def job():
         logger.error(f"Error fetching job: {str(e)}", exc_info=True)
         raise HTTPException(status_code=500, detail="Internal Server Error")
 
+
+@app.post("/session/start")
+@limiter.limit("30/minute")
+def session_start(request: Request, data: dict):
+    """
+    Start a new anti-cheat game session. Returns a session_token that must be
+    included in subsequent /validate and /game_over calls.
+
+    Body:
+        mode (str): "classic" | "highlow"
+    """
+    mode = data.get("mode", "classic")
+    if mode not in ("classic", "highlow"):
+        raise HTTPException(status_code=400, detail="Invalid game mode")
+    token = create_session(mode)
+    return {"session_token": token}
+
+
 @app.post("/validate")
-def validate(data: dict):
+@limiter.limit("120/minute")
+def validate(request: Request, data: dict):
     """
     Validate a user's guess (numeric or comparison) against server-side data.
+    Optionally record per-round score into a session for anti-cheat.
     """
     job_id = data.get("job_id")
     guess = data.get("guess")
-    other_job_id = data.get("other_job_id") # For High/Low mode
-    
+    other_job_id = data.get("other_job_id")  # For High/Low mode
+    session_token = data.get("session_token")  # Anti-cheat session
+
     if not job_id:
         raise HTTPException(status_code=400, detail="Missing job_id")
-        
+
     salary_data = get_job_salary_data(job_id)
     if not salary_data:
         raise HTTPException(status_code=404, detail="Job salary not found in cache")
-        
+
     real_salary = salary_data.get("value")
     original_salaire = salary_data.get("original_salaire")
 
@@ -152,13 +193,12 @@ def validate(data: dict):
         other_data = get_job_salary_data(other_job_id)
         if not other_data:
             raise HTTPException(status_code=404, detail="Comparison job salary not found")
-        
+
         other_salary = other_data.get("value")
-        
-        # Real comparison result
+
         is_equal = abs(real_salary - other_salary) < 1
         is_higher = real_salary > other_salary
-        
+
         correct = False
         if is_equal:
             correct = True
@@ -166,7 +206,11 @@ def validate(data: dict):
             correct = is_higher
         elif guess == "lower":
             correct = not is_higher
-            
+
+        # Anti-cheat: record streak increment server-side
+        if correct and session_token:
+            increment_streak(session_token)
+
         return {
             "correct": correct,
             "real_salary": real_salary,
@@ -176,21 +220,23 @@ def validate(data: dict):
 
     # CASE 2: Just reveal salary (if guess is None)
     if guess is None:
-        return {
-            "real_salary": real_salary
-        }
+        return {"real_salary": real_salary}
 
     # CASE 3: Numeric guess
     try:
         guess_val = float(guess)
         real_val = float(real_salary)
-        
+
         error_ratio = abs(guess_val - real_val) / real_val
         score = 0
         if error_ratio <= 0.5:
             x = error_ratio / 0.5
             score = 100 * ((1 - x) ** 2)
-            
+
+        # Anti-cheat: record per-round score server-side
+        if session_token:
+            record_round_score(session_token, score)
+
         return {
             "job_id": job_id,
             "real_salary": real_val,
@@ -202,25 +248,71 @@ def validate(data: dict):
         logger.warning(f"Invalid guess attempt: {str(e)}")
         raise HTTPException(status_code=400, detail="Invalid guess or salary data")
 
-@app.post("/log")
-async def client_log(data: dict):
+
+@app.post("/game_over")
+@limiter.limit("30/minute")
+def game_over(request: Request, data: dict):
     """
-    Endpoint for frontend logs. Writes to frontend.log.
+    Finalize a game session. The server computes and logs the final score
+    based on the accumulated round scores — the client never submits a score.
+
+    Body:
+        session_token (str): The token from /session/start.
+    """
+    session_token = data.get("session_token")
+    if not session_token:
+        raise HTTPException(status_code=400, detail="Missing session_token")
+
+    result = finalize_session(session_token)
+    if not result:
+        raise HTTPException(status_code=404, detail="Session not found or already finalized")
+
+    mode = result["mode"]
+    score = result["score"]
+
+    # Write the authoritative log entry server-side
+    if mode == "classic":
+        frontend_logger.info("Classic game finished", extra={"extra_data": {"score": score, "rounds": result.get("rounds", 0)}})
+    elif mode == "highlow":
+        frontend_logger.info("High/Low game over", extra={"extra_data": {"finalScore": score}})
+
+    logger.info(f"[ANTI-CHEAT] Game over logged server-side: mode={mode}, score={score}")
+    return {"mode": mode, "score": score}
+
+
+@app.post("/log")
+@limiter.limit("60/minute")
+async def client_log(request: Request, data: dict):
+    """
+    Endpoint for frontend logs. Only accepts allowlisted event messages.
+    Score data is IGNORED — scores are written by /game_over server-side.
     """
     level = data.get("level", "info").lower()
     message = data.get("message", "No message")
     context = data.get("context", {})
-    
-    log_data = {"extra_data": context}
-    
+
+    # SECURITY: Reject any message not in the explicit allowlist
+    if message.lower() not in ALLOWED_LOG_MESSAGES:
+        # Silently ignore — don't give attacker feedback
+        return {"status": "ok"}
+
+    # Strip any score fields to prevent injection
+    safe_context = {
+        k: v for k, v in context.items()
+        if k not in ("score", "finalScore", "avgScore", "points")
+    }
+
+    log_data = {"extra_data": safe_context}
+
     if level == "error":
         frontend_logger.error(message, extra=log_data)
     elif level == "warning":
         frontend_logger.warning(message, extra=log_data)
     else:
         frontend_logger.info(message, extra=log_data)
-        
+
     return {"status": "ok"}
+
 
 # Simple in-memory cache for stats
 stats_cache = {"data": None, "expiry": 0}
@@ -233,21 +325,22 @@ async def global_stats():
     now = time.time()
     if stats_cache["data"] and now < stats_cache["expiry"]:
         return stats_cache["data"]
-    
+
     try:
         data = get_global_stats()
         stats_cache["data"] = data
-        stats_cache["expiry"] = now + 60 # 1 minute cache
+        stats_cache["expiry"] = now + 60  # 1 minute cache
         return data
     except Exception as e:
         logger.error(f"Error generating global stats: {str(e)}")
         raise HTTPException(status_code=500, detail="Could not generate stats")
 
+
 @app.get("/stats")
 def stats():
     """
     Retrieve statistics about the offer pool and played jobs.
-    
+
     Returns:
         dict: Played count, current pool size, and environment.
     """
@@ -257,20 +350,26 @@ def stats():
         "environment": ENVIRONMENT
     }
 
+
 @app.post("/reset")
-def reset():
+def reset(x_admin_key: str = Header(None)):
     """
     Reset the game state, clear the pool, and rebuild it.
-    
+    PROTECTED: Requires X-Admin-Key header matching ADMIN_SECRET_KEY env var.
+
     Returns:
         dict: Success message.
     """
+    if not ADMIN_SECRET_KEY or x_admin_key != ADMIN_SECRET_KEY:
+        raise HTTPException(status_code=403, detail="Forbidden")
+
     with threading.Lock():
         clear_played()
         OFFER_POOL.clear()
-        refill_in_progress = False
     build_offer_pool(POOL_TARGET_SIZE)
+    cleanup_old_sessions()
     return {"message": "Full reset complete"}
+
 
 # Startup logic moved to lifespan
 

--- a/backend/utils/sessions.py
+++ b/backend/utils/sessions.py
@@ -1,0 +1,94 @@
+"""
+Server-side session store for anti-cheat score tracking.
+Sessions are short-lived in-memory dicts. They are created when a game starts
+and finalized (deleted) when the game ends. The server computes all scores.
+"""
+
+import uuid
+import time
+import threading
+
+SESSION_TTL_SECONDS = 3600  # 1 hour max per game session
+_sessions = {}
+_lock = threading.Lock()
+
+# --- Allowed log event types from the frontend ---
+ALLOWED_LOG_MESSAGES = {
+    "landing page visit",
+    "classic game started",
+    "high/low game started",
+    "battle royale game started",
+}
+
+
+def create_session(mode: str) -> str:
+    """Create a new game session and return a unique session_token."""
+    token = uuid.uuid4().hex
+    with _lock:
+        _sessions[token] = {
+            "mode": mode,
+            "created_at": time.time(),
+            "round_scores": [],  # list of per-round scores (Classic mode)
+            "streak": 0,         # consecutive correct answers (High/Low mode)
+            "finalized": False,
+        }
+    return token
+
+
+def get_session(token: str) -> dict | None:
+    """Retrieve a session by token, or None if not found / expired."""
+    with _lock:
+        s = _sessions.get(token)
+        if s is None:
+            return None
+        if time.time() - s["created_at"] > SESSION_TTL_SECONDS:
+            del _sessions[token]
+            return None
+        return s
+
+
+def record_round_score(token: str, score: float):
+    """Append a per-round score to the session (Classic mode)."""
+    with _lock:
+        s = _sessions.get(token)
+        if s and not s["finalized"]:
+            s["round_scores"].append(score)
+
+
+def increment_streak(token: str):
+    """Increment the streak counter for High/Low mode."""
+    with _lock:
+        s = _sessions.get(token)
+        if s and not s["finalized"]:
+            s["streak"] += 1
+
+
+def finalize_session(token: str) -> dict | None:
+    """
+    Mark session as finalized and return computed results.
+    Returns None if session not found.
+    """
+    with _lock:
+        s = _sessions.get(token)
+        if not s or s["finalized"]:
+            return None
+        s["finalized"] = True
+
+        mode = s["mode"]
+        if mode == "classic":
+            rounds = s["round_scores"]
+            avg = sum(rounds) / len(rounds) if rounds else 0
+            return {"mode": mode, "score": round(avg, 2), "rounds": len(rounds)}
+        elif mode == "highlow":
+            return {"mode": mode, "score": s["streak"]}
+        else:
+            return {"mode": mode, "score": 0}
+
+
+def cleanup_old_sessions():
+    """Prune all expired sessions (call periodically or on demand)."""
+    now = time.time()
+    with _lock:
+        expired = [t for t, s in _sessions.items() if now - s["created_at"] > SESSION_TTL_SECONDS]
+        for t in expired:
+            del _sessions[t]

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.1.0-beta",
+  "version": "0.3.2-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.1.0-beta",
+      "version": "0.3.2-beta",
       "dependencies": {
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.3.2-beta",
+  "version": "0.3.3-beta",
   "private": true,
   "dependencies": {
     "@testing-library/dom": "^10.4.1",

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -14,7 +14,9 @@ import "../styles/GamePage.css";
 import {
   fetchJob,
   hasValidSalary,
-  validateGuess
+  validateGuess,
+  startSession,
+  reportGameOver,
 } from "../utils/gameUtils";
 import { useSound } from "../sound/SoundProvider";
 import { useSettings } from "../context/SettingsContext";
@@ -73,6 +75,7 @@ export default function GamePage() {
   const jobBufferRef = useRef([]);
   const refillPromiseRef = useRef(null);
   const seenIdsRef = useRef(new Set());
+  const sessionTokenRef = useRef(null);
 
   /**
    * Fetches a single job from the API and ensures it has a valid salary
@@ -153,12 +156,17 @@ export default function GamePage() {
     setScore(0);
     setHistory([]);
     seenIdsRef.current.clear();
+    sessionTokenRef.current = null;
 
     setGuess("");
     setResult(null);
     setShowResult(false);
 
     try {
+      // Start an anti-cheat session before fetching jobs
+      const token = await startSession("classic");
+      sessionTokenRef.current = token;
+
       const firstJob = await fetchNormalizedJobWithSalary();
       seenIdsRef.current.add(firstJob.id);
       setCurrentJob(firstJob);
@@ -183,7 +191,7 @@ export default function GamePage() {
     
     setLoadingJob(true);
     try {
-      const response = await validateGuess(currentJob.id, userBaseValue);
+      const response = await validateGuess(currentJob.id, userBaseValue, sessionTokenRef.current);
       
       const realDisplayValue = convertFromBase(response.real_salary);
       const scoreValue = response.score;
@@ -234,7 +242,8 @@ export default function GamePage() {
       } else {
         play("gameEnd3");
       }
-      logger.info("Classic game finished", { score: avgScore });
+      // Anti-cheat: server computes and logs the authoritative final score
+      reportGameOver(sessionTokenRef.current);
       return;
     }
 

--- a/frontend/src/pages/HighLowGame.jsx
+++ b/frontend/src/pages/HighLowGame.jsx
@@ -6,7 +6,9 @@ import {
   fetchJob,
   fetchMultipleJobs,
   validateGuess,
-  validateComparison
+  validateComparison,
+  startSession,
+  reportGameOver,
 } from "../utils/gameUtils";
 import { useSound } from "../sound/SoundProvider";
 import { useSettings } from "../context/SettingsContext";
@@ -36,6 +38,7 @@ export default function HighLowGame() {
   const [showSalary, setShowSalary] = useState(false);
   const [guessResult, setGuessResult] = useState(null);
   const [isWaiting, setIsWaiting] = useState(false);
+  const sessionTokenRef = useRef(null);
   /**
    * Initializes the game state and fetches the first set of jobs.
    * 
@@ -49,11 +52,16 @@ export default function HighLowGame() {
     setShowSalary(false);
     setGuessResult(null);
     setIsWaiting(false);
+    sessionTokenRef.current = null;
 
     try {
+      // Start an anti-cheat session
+      const token = await startSession("highlow");
+      sessionTokenRef.current = token;
+
       const newJobs = await fetchMultipleJobs(2);
       if (newJobs.length > 0) {
-        const reveal = await validateGuess(newJobs[0].id);
+        const reveal = await validateGuess(newJobs[0].id, null, token);
         newJobs[0].baseSalary = reveal.real_salary;
       }
       setJobs(newJobs);
@@ -77,7 +85,7 @@ export default function HighLowGame() {
     const rightJob = jobs[currentIndex + 1];
 
     try {
-      const response = await validateComparison(rightJob.id, leftJob.id, guess);
+      const response = await validateComparison(rightJob.id, leftJob.id, guess, sessionTokenRef.current);
 
       const updatedJobs = [...jobs];
       updatedJobs[currentIndex + 1].baseSalary = response.real_salary;
@@ -109,7 +117,8 @@ export default function HighLowGame() {
       } else {
         play("gameEnd");
         setGuessResult("wrong");
-        logger.info("High/Low game over", { finalScore: score });
+        // Anti-cheat: server computes and logs the authoritative final score
+        reportGameOver(sessionTokenRef.current);
         setTimeout(() => setGameOver(true), 1500);
       }
     } catch (err) {

--- a/frontend/src/utils/gameUtils.js
+++ b/frontend/src/utils/gameUtils.js
@@ -92,16 +92,61 @@ export async function fetchMultipleJobs(count) {
 }
 
 /**
+ * Start a new anti-cheat game session on the server.
+ * @param {"classic"|"highlow"} mode
+ * @returns {Promise<string>} The session_token to include in validate calls.
+ */
+export async function startSession(mode) {
+  try {
+    const res = await fetch(`${API_URL}/session/start`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ mode }),
+    });
+    if (!res.ok) return null;
+    const data = await res.json();
+    return data.session_token ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Finalize a game session. Server computes the authoritative score and logs it.
+ * @param {string} sessionToken
+ * @returns {Promise<object|null>} { mode, score } or null on failure.
+ */
+export async function reportGameOver(sessionToken) {
+  if (!sessionToken) return null;
+  try {
+    const res = await fetch(`${API_URL}/game_over`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ session_token: sessionToken }),
+    });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Validate a salary guess with the backend (Anti-Cheat).
- * @param {string} jobId 
- * @param {number} guess 
+ * @param {string} jobId
+ * @param {number} guess
+ * @param {string|null} sessionToken
  * @returns {Promise<object>}
  */
-export async function validateGuess(jobId, guess) {
+export async function validateGuess(jobId, guess, sessionToken = null) {
+  const body = { job_id: jobId };
+  if (guess !== undefined && guess !== null) body.guess = Number(guess);
+  if (sessionToken) body.session_token = sessionToken;
+
   const res = await fetch(`${API_URL}/validate`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ job_id: jobId, guess: Number(guess) }),
+    body: JSON.stringify(body),
   });
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   return await res.json();
@@ -109,20 +154,24 @@ export async function validateGuess(jobId, guess) {
 
 /**
  * Validate a higher/lower comparison between two jobs (Anti-Cheat).
- * @param {string} jobIdToGuess 
- * @param {string} knownJobId 
+ * @param {string} jobIdToGuess
+ * @param {string} knownJobId
  * @param {string} guess "higher" or "lower"
+ * @param {string|null} sessionToken
  * @returns {Promise<object>}
  */
-export async function validateComparison(jobIdToGuess, knownJobId, guess) {
+export async function validateComparison(jobIdToGuess, knownJobId, guess, sessionToken = null) {
+  const body = {
+    job_id: jobIdToGuess,
+    other_job_id: knownJobId,
+    guess,
+  };
+  if (sessionToken) body.session_token = sessionToken;
+
   const res = await fetch(`${API_URL}/validate`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      job_id: jobIdToGuess,
-      other_job_id: knownJobId,
-      guess
-    }),
+    body: JSON.stringify(body),
   });
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   return await res.json();

--- a/setup.bat
+++ b/setup.bat
@@ -25,7 +25,7 @@ REM Activation et installation
 echo Installation des packages Python...
 call venv\Scripts\activate.bat
 pip install --upgrade pip
-pip install fastapi "uvicorn[standard]" requests beautifulsoup4 python-dotenv python-socketio==5.9.0 python-engineio==4.7.0 websockets wsproto sphinx sphinx-rtd-theme pytest pytest-asyncio httpx pytest-cov
+pip install fastapi "uvicorn[standard]" requests beautifulsoup4 python-dotenv python-socketio==5.9.0 python-engineio==4.7.0 websockets wsproto sphinx sphinx-rtd-theme pytest pytest-asyncio httpx pytest-cov slowapi
 
 echo.
 echo Backend installe avec succes !

--- a/setup.sh
+++ b/setup.sh
@@ -24,7 +24,7 @@ python3 -m venv venv
 echo "Installation des packages Python..."
 source venv/bin/activate
 pip install --upgrade pip
-pip install fastapi "uvicorn[standard]" requests beautifulsoup4 python-dotenv python-socketio==5.9.0 python-engineio==4.7.0 websockets wsproto sphinx sphinx-rtd-theme pytest pytest-asyncio httpx pytest-cov
+pip install fastapi "uvicorn[standard]" requests beautifulsoup4 python-dotenv python-socketio==5.9.0 python-engineio==4.7.0 websockets wsproto sphinx sphinx-rtd-theme pytest pytest-asyncio httpx pytest-cov slowapi
 
 echo ""
 echo "Backend installe avec succes !"


### PR DESCRIPTION
# Security: Server-side score tracking and rate limiting

## What changed

The game had no server-side score validation. The frontend sent its own score to the `/log` endpoint, which was used to build the global stats. Anyone could send a fake score by replaying or crafting a request.

## Changes

### Backend

**`backend/utils/sessions.py`** (new file)
- In-memory session store keyed by a UUID token.
- Tracks per-round scores (Classic) and win streaks (High/Low) server-side.
- Sessions expire after 1 hour.
- Holds the allowlist of valid log message strings.

**`backend/main.py`**
- Added `slowapi` rate limiting: `/job` at 60/min, `/validate` at 120/min, `/log` and `/game_over` at 30/min per IP.
- `POST /session/start` — issues a session token at game start.
- `POST /validate` — now records each round score into the session server-side when a token is provided.
- `POST /game_over` — finalizes the session, computes the final score server-side, and writes the log. The client sends no score.
- `POST /log` — rejects any message not in the allowlist. Strips all score-related fields (`score`, `finalScore`, etc.) from the context.
- `POST /reset` — now requires an `X-Admin-Key` header matching `ADMIN_SECRET_KEY`. Returns 403 otherwise.
- Socket.IO CORS changed from `'*'` to `CORS_ORIGINS`.

**`backend/config.py`**
- Added `ADMIN_SECRET_KEY` from env.

**`setup.bat` / `setup.sh`**
- Added `slowapi` to the pip install command.

**`.env.example`**
- Added `ADMIN_SECRET_KEY` with a generation command.

### Frontend

**`frontend/src/utils/gameUtils.js`**
- Added `startSession(mode)` — calls `POST /session/start`, returns the token.
- Added `reportGameOver(sessionToken)` — calls `POST /game_over`.
- Updated `validateGuess` and `validateComparison` to accept an optional `sessionToken` parameter.

**`frontend/src/pages/GamePage.jsx`**
- Calls `startSession("classic")` at game start.
- Passes the token to `validateGuess` on each round.
- Calls `reportGameOver()` at game end instead of `logger.info` with a score.

**`frontend/src/pages/HighLowGame.jsx`**
- Same pattern as GamePage for `"highlow"` mode.

## Deployment note

Add `ADMIN_SECRET_KEY` to your `.env` before restarting the server:

```bash
echo "ADMIN_SECRET_KEY=$(python3 -c 'import secrets; print(secrets.token_hex(32))')" >> .env
```
